### PR TITLE
Remove return type dependency of filter step

### DIFF
--- a/spec/Step/FilterStepSpec.php
+++ b/spec/Step/FilterStepSpec.php
@@ -43,7 +43,7 @@ class FilterStepSpec extends ObjectBehavior
             return false;
         })->shouldReturn($this);
 
-        $this->process(
+        $this->shouldThrow('Port\Steps\Exception\FilterException')->duringProcess(
             $item,
             function($item) use ($step, $next) {
                 return $step->process($item, $next);

--- a/src/Exception/FilterException.php
+++ b/src/Exception/FilterException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Port\Steps\Exception;
+
+use Port\Exception;
+
+/**
+ * Thrown when the processing of the pipeline should be stopped
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+class FilterException extends \Exception implements Exception
+{
+
+}

--- a/src/Step/FilterStep.php
+++ b/src/Step/FilterStep.php
@@ -2,6 +2,7 @@
 
 namespace Port\Steps\Step;
 
+use Port\Steps\Exception\FilterException;
 use Port\Steps\Step;
 
 /**
@@ -39,7 +40,7 @@ class FilterStep implements Step
     {
         foreach (clone $this->filters as $filter) {
             if (false === call_user_func($filter, $item)) {
-                return false;
+                throw new FilterException();
             }
         }
 

--- a/src/StepAggregator.php
+++ b/src/StepAggregator.php
@@ -9,6 +9,7 @@ use Port\Step\PriorityStep;
 use Port\Workflow;
 use Port\Writer;
 use Port\Steps\Exception\BreakException;
+use Port\Steps\Exception\FilterException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -114,9 +115,9 @@ class StepAggregator implements Workflow, LoggerAwareInterface
         // Read all items
         foreach ($this->reader as $index => $item) {
             try {
-                if (false === $pipeline($item)) {
-                    continue;
-                }
+                $pipeline($item);
+            } catch(FilterException $e) {
+                continue;
             } catch(BreakException $e) {
                 break;
             } catch(Exception $e) {


### PR DESCRIPTION
We have already been talking about using exceptions in a workflow and we agreed we should keep their number low as exceptions require more resources. I am still opening this PR now, because I think we should remove the return type dependency from steps.

Thinking about filters: if a filter must be used too much times, then the workflow is possibly badly constructed. Big data feeds should be filtered as much as possible prior to processing with Port.

What do you think?
