### PR TITLE
Fix line number bug when exceptions are on

### DIFF
--- a/spec/Step/ValidatorStepSpec.php
+++ b/spec/Step/ValidatorStepSpec.php
@@ -94,7 +94,7 @@ class ValidatorStepSpec extends ObjectBehavior
         );
     }
 
-    function it_increments_line_number_when_when_exceptions_are_on(
+    function it_increments_line_number_when_exceptions_are_on(
         Step $step,
         ValidatorInterface $validator,
         Constraint $constraint,

--- a/src/Step/ValidatorStep.php
+++ b/src/Step/ValidatorStep.php
@@ -90,7 +90,10 @@ class ValidatorStep implements PriorityStep
             $this->violations[$this->line] = $list;
 
             if ($this->throwExceptions) {
-                throw new ValidationException($list, $this->line);
+                $exception = new ValidationException($list, $this->line);
+                $this->line++;
+
+                throw $exception;
             }
         }
 

--- a/src/Step/ValidatorStep.php
+++ b/src/Step/ValidatorStep.php
@@ -90,10 +90,10 @@ class ValidatorStep implements PriorityStep
             $this->violations[$this->line] = $list;
 
             if ($this->throwExceptions) {
-                $exception = new ValidationException($list, $this->line);
+                $errorLine = $this->line;
                 $this->line++;
 
-                throw $exception;
+                throw new ValidationException($list, $errorLine);
             }
         }
 


### PR DESCRIPTION
Hi,

I found a bug: when `throwExceptions` is switched on, the line number does not get incremented and so every error appears to come from line 1. PR includes spec example and fix.