### PR TITLE
use array_search instead of isset,

### DIFF
--- a/src/Step/MappingStep.php
+++ b/src/Step/MappingStep.php
@@ -63,7 +63,7 @@ class MappingStep implements Step
 
                 // Check if $item is an array, because properties can't be unset.
                 // So we don't call unset for objects to prevent side affects.
-                if (is_array($item) && isset($item[$from])) {
+                if (is_array($item) && array_search($from, $item) !== false) {
                     unset($item[$from]);
                 }
             }


### PR DESCRIPTION
because  isset() will return FALSE if testing a variable that has been set to NULL
Which means any 'from' part being NULL is not cleared