### PR TITLE
Add support for validation from metadata (e.g., annotations)

### DIFF
--- a/spec/Step/ValidatorStepSpec.php
+++ b/spec/Step/ValidatorStepSpec.php
@@ -93,4 +93,21 @@ class ValidatorStepSpec extends ObjectBehavior
             }
         );
     }
+
+    function it_validates_an_item_from_metadata(
+        ValidatorInterface $validator,
+        ConstraintViolationListInterface $list
+    ) {
+        $next = function() {};
+        $list->count()->willReturn(1);
+        $item = new \stdClass();
+        $validator->validate($item)->willReturn($list);
+
+        $this->process(
+            $item,
+            $next
+        );
+
+        $this->getViolations()->shouldReturn([1 => $list]);
+    }
 }

--- a/src/Step/ValidatorStep.php
+++ b/src/Step/ValidatorStep.php
@@ -83,8 +83,12 @@ class ValidatorStep implements PriorityStep
      */
     public function process($item, callable $next)
     {
-        $constraints = new Constraints\Collection($this->constraints);
-        $list = $this->validator->validate($item, $constraints);
+        if (count($this->constraints) > 0) {
+            $constraints = new Constraints\Collection($this->constraints);
+            $list = $this->validator->validate($item, $constraints);
+        } else {
+            $list = $this->validator->validate($item);
+        }
 
         if (count($list) > 0) {
             $this->violations[$this->line] = $list;


### PR DESCRIPTION
Add support for validation constraints from annotations (or other [validation metadata sources](http://symfony.com/doc/current/components/validator/resources.html)).

Fix portphp/portphp#57.