### PR TITLE
Fix the line counter tracking when validation exception are thrown 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ $ composer install
 Write your code and add tests. Then run the tests:
 
 ```bash
-$ vendor/bin/phpunit
+$ vendor/bin/phpspec run
 ```
 
 Commit your changes and push them to GitHub:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ $ composer install
 Write your code and add tests. Then run the tests:
 
 ```bash
+$ vendor/bin/phpunit
 $ vendor/bin/phpspec run
 ```
 

--- a/spec/Step/ValidatorStepSpec.php
+++ b/spec/Step/ValidatorStepSpec.php
@@ -127,4 +127,52 @@ class ValidatorStepSpec extends ObjectBehavior
 
         $this->getViolations()->shouldReturn([1 => $list]);
     }
+
+    function it_validates_multiple_items_from_metadata(
+        ValidatorInterface $validator,
+        ConstraintViolationListInterface $list
+    )
+    {
+        $numberOfCalls = 3;
+        $next = function() {};
+        $list->count()->willReturn(1);
+        $item = new \stdClass();
+        $validator->validate($item)->willReturn($list);
+
+        for ($i = 0; $i < $numberOfCalls; $i++) {
+            $this->process($item, $next);
+        }
+
+        $this->getViolations()->shouldReturn(array_fill(1, $numberOfCalls, $list));
+    }    
+
+    function it_tracks_lines_when_exceptions_are_thrown_during_process(
+        Step $step,
+        ValidatorInterface $validator,
+        Constraint $constraint,
+        ConstraintViolation $violation
+    )
+    {
+        $numberOfCalls = 3;
+        $next = function() {};
+        $errorList = new ConstraintViolationList([$violation->getWrappedObject()]);
+        $stepFunc = function($item) use ($step, $next) {
+            return $step->process($item, $next);
+        };
+        $item = ['foo' => 10];
+
+        $validator->validate($item, Argument::type('Symfony\Component\Validator\Constraints\Collection'))
+            ->willReturn($errorList);
+
+        $step->process($item, $next)->shouldNotBeCalled();
+
+        $this->throwExceptions();
+        $this->add('foo', $constraint)->shouldReturn($this);
+
+        for ($i = 0; $i < $numberOfCalls; $i++) {
+            $this->shouldThrow('Port\Exception\ValidationException')->duringProcess($item, $stepFunc);
+        }
+
+        $this->getViolations()->shouldReturn(array_fill(1, $numberOfCalls, $errorList));
+    }
 }

--- a/src/Step/ValidatorStep.php
+++ b/src/Step/ValidatorStep.php
@@ -30,7 +30,7 @@ class ValidatorStep implements PriorityStep
     /**
      * @var integer
      */
-    private $line = 1;
+    private $line = 0;
 
     /**
      * @var ValidatorInterface
@@ -98,6 +98,8 @@ class ValidatorStep implements PriorityStep
      */
     public function process($item, callable $next)
     {
+        $this->line++;
+
         if (count($this->constraints) > 0) {
             $constraints = new Constraints\Collection($this->constraints);
             $list = $this->validator->validate($item, $constraints);
@@ -112,8 +114,6 @@ class ValidatorStep implements PriorityStep
                 throw new ValidationException($list, $this->line);
             }
         }
-
-        $this->line++;
 
         if (0 === count($list)) {
             return $next($item);


### PR DESCRIPTION
This corrects the `$exception->getLineNumber()` value when validation fails for particular lines in a dataset (especially when using getViolations). Before, the subsequent line numbers would 'stick' instead of correctly matching up with the source file.

This came about when listing all the violations and line numbers, and them not matching up to the source data.

Test added for multiple-item processing which verify the violations line number result.