### PR TITLE
Fix unexpected unset when $from and $to have the same value

### DIFF
--- a/src/Step/MappingStep.php
+++ b/src/Step/MappingStep.php
@@ -63,7 +63,8 @@ class MappingStep implements Step
 
                 // Check if $item is an array, because properties can't be unset.
                 // So we don't call unset for objects to prevent side affects.
-                if (is_array($item) && array_key_exists($from, $item)) {
+                // Also, we don't have to unset the property if the key is the same
+                if (is_array($item) && array_key_exists($from, $item) && $from !== str_replace(['[',']'], '', $to)) {
                     unset($item[$from]);
                 }
             }


### PR DESCRIPTION
If you set a map with the same key, that will be unexpectedly unset.
For example:
```php
$mappingStep = new MappingStep();
$mappingStep
    ->map('[name]', '[name]')
    ->map('[surname]', '[surname]')
    ->map('[cellphone]', '[telephone]');
```
With this mapping, `name` and `surname` will be unsettled and lost during workflow execution.
This is unexpected. I fixed that just adding a little check more.