### PR TITLE
CI: modernize GitHub Actions (PHP 8.2–8.5)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,49 +6,42 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
-        php-versions: [ '7.4', '8.0', '8.1' ]
-        include:
-          - php-versions: '7.4'
-            coverage: pcov
-            composer-prefer: '--prefer-lowest --prefer-stable'
-            phpunit-flags: '--coverage-clover coverage.xml'
+        php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          coverage: ${{ matrix.coverage }}
+          coverage: none
+          tools: composer:v2
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict
+
+      - name: Validate composer.json
+        run: composer validate --strict --no-check-lock
 
       - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-composer-${{ matrix.composer-prefer }}$-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-composer-${{ matrix.composer-prefer }}-
+            ${{ runner.os }}-composer-${{ matrix.php-versions }}-
 
       - name: Install dependencies
-        run: composer update --prefer-dist --no-progress --ignore-platform-req="ext-*" ${{ matrix.composer-prefer }}
+        run: composer update --prefer-dist --no-progress --ignore-platform-req="ext-*"
 
       - name: Run phpspec
-        run: vendor/bin/phpspec run
-        continue-on-error: true
-
-      - name: Upload coverage
-        if: matrix.coverage
-        run: |
-          wget https://scrutinizer-ci.com/ocular.phar
-          php ocular.phar code-coverage:upload --format=php-clover coverage.xml --revision=${{ github.event.pull_request.head.sha || github.sha }}
+        run: vendor/bin/phpspec run --config phpspec.yml.dist

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
         "symfony/validator": "<2.5"
     },
     "require-dev": {
-        "phpspec/phpspec": "^7.2",
-        "friends-of-phpspec/phpspec-code-coverage": "^6.1"
+        "phpspec/phpspec": "^7.2 || ^8.0",
+        "friends-of-phpspec/phpspec-code-coverage": "^6.1 || ^7.0"
     },
     "suggest": {
         "symfony/property-access": "Used in MappingStep",

--- a/spec/Step/ValidatorStepSpec.php
+++ b/spec/Step/ValidatorStepSpec.php
@@ -103,6 +103,7 @@ class ValidatorStepSpec extends ObjectBehavior
         $next = function() {};
         $item = ['foo' => true];
         $step->process($item, $next)->shouldNotBeCalled();
+        $violation->getMessage()->willReturn('Invalid value');
         $list = new ConstraintViolationList([$violation->getWrappedObject()]);
         $validator->validate($item, Argument::type('Symfony\Component\Validator\Constraints\Collection'))->willReturn($list);
 
@@ -163,6 +164,7 @@ class ValidatorStepSpec extends ObjectBehavior
     {
         $numberOfCalls = 3;
         $next = function() {};
+        $violation->getMessage()->willReturn('Invalid value');
         $errorList = new ConstraintViolationList([$violation->getWrappedObject()]);
         $stepFunc = function($item) use ($step, $next) {
             return $step->process($item, $next);


### PR DESCRIPTION
## Summary
Phase 0 housekeeping for green, maintainable CI.

- Bump `actions/checkout` and `actions/cache` to **v4** (v2 is blocked on current runners)
- Matrix: **PHP 8.2–8.5**
- Remove Scrutinizer/ocular upload
- Remove `continue-on-error` on phpspec so red means red
- Run phpspec via `phpspec.yml.dist` (no coverage extension required in CI)
- Allow `phpspec/phpspec` `^7.2 || ^8.0` so installs resolve on PHP 8.4/8.5

Part of PortPHP org CI modernization (Phase 0).