### PR TITLE
Align PHP requirement with CI matrix (Copilot feedback)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,13 +30,18 @@ jobs:
 
 
       - name: Validate composer.json
-        run: composer validate --strict --no-check-lock
+        run: |
+          if [ -f composer.lock ]; then
+            composer validate --strict
+          else
+            composer validate --strict --no-check-lock
+          fi
 
       - name: Cache Composer packages
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.json', '**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-${{ matrix.php-versions }}-
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,12 @@ jobs:
             ${{ runner.os }}-composer-${{ matrix.php-versions }}-
 
       - name: Install dependencies
-        run: composer update --prefer-dist --no-progress --ignore-platform-req="ext-*"
+        run: |
+          if [ -f composer.lock ]; then
+            composer install --prefer-dist --no-progress
+          else
+            composer update --prefer-dist --no-progress
+          fi
 
       - name: Run phpspec
         run: vendor/bin/phpspec run --config phpspec.yml.dist

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,12 +29,12 @@ jobs:
           tools: composer:v2
 
 
-      - name: Validate composer.json
+      - name: Validate Composer metadata
         run: |
           if [ -f composer.lock ]; then
-            composer validate --strict
+            composer validate --strict --no-interaction
           else
-            composer validate --strict --no-check-lock
+            composer validate --strict --no-check-lock --no-interaction
           fi
 
       - name: Cache Composer packages
@@ -48,9 +48,9 @@ jobs:
       - name: Install dependencies
         run: |
           if [ -f composer.lock ]; then
-            composer install --prefer-dist --no-progress
+            composer install --prefer-dist --no-progress --no-interaction
           else
-            composer update --prefer-dist --no-progress
+            composer update --prefer-dist --no-progress --no-interaction
           fi
 
       - name: Run phpspec

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "docs": "https://portphp.readthedocs.org"
     },
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=8.2",
         "portphp/portphp": "^1.0.0",
         "seld/signal-handler": "^1.0 || ^2.0",
         "symfony/property-access": "^2.3 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "docs": "https://portphp.readthedocs.org"
     },
     "require": {
-        "php": ">=8.2",
+        "php": "^8.2",
         "portphp/portphp": "^1.0.0",
         "seld/signal-handler": "^1.0 || ^2.0",
         "symfony/property-access": "^2.3 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",


### PR DESCRIPTION
## Summary
Follow-up to #24 addressing [Copilot review feedback](https://github.com/portphp/steps/pull/24#discussion_r3629694601).

- Raise `php` requirement from `>=5.6.0` to **`^8.2`** so declared support matches the CI matrix (and does not auto-accept PHP 9+)
- Validate `composer.lock` when present; keep `--no-check-lock` only when missing
- Prefer `composer install` when a lockfile is present
- Include `composer.lock` in the Actions cache key hash
- Run Composer with `--no-interaction`

## Test plan
- [x] CI matrix PHP 8.2–8.5 green
- [x] Copilot review on latest commit (no blocking comments)