### PR TITLE
Update README CI badges and drop Scrutinizer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,6 @@ spec/            export-ignore
 .editorconfig    export-ignore
 .gitattributes   export-ignore
 .gitignore       export-ignore
-.scrutinizer.yml export-ignore
-.travis.yml      export-ignore
 CONTRIBUTING.md  export-ignore
 phpspec.yml.ci   export-ignore
 phpspec.yml.dist export-ignore

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,0 @@
-checks:
-  php:
-    code_rating: true
-    duplication: true
-
-tools:
-  external_code_coverage: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # portphp/steps
 
 [![Latest Version](https://img.shields.io/github/release/portphp/steps.svg?style=flat-square)](https://github.com/portphp/steps/releases)
-[![CI](https://github.com/portphp/steps/actions/workflows/checks.yml/badge.svg?branch=master)](https://github.com/portphp/steps/actions)
+[![CI](https://github.com/portphp/steps/actions/workflows/checks.yml/badge.svg?branch=master)](https://github.com/portphp/steps/actions/workflows/checks.yml)
 [![PHP Version](https://img.shields.io/packagist/php-v/portphp/steps.svg?style=flat-square)](https://packagist.org/packages/portphp/steps)
 
 **Requirements:** PHP ^8.2 (tested on 8.2–8.5).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # portphp/steps
 
 [![Latest Version](https://img.shields.io/github/release/portphp/steps.svg?style=flat-square)](https://github.com/portphp/steps/releases)
-[![Build Status](https://travis-ci.org/portphp/steps.svg)](https://travis-ci.org/portphp/steps)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/portphp/steps/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/portphp/steps/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/portphp/steps/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/portphp/steps/?branch=master)
+[![CI](https://github.com/portphp/steps/actions/workflows/checks.yml/badge.svg?branch=master)](https://github.com/portphp/steps/actions)
+[![PHP Version](https://img.shields.io/packagist/php-v/portphp/steps.svg?style=flat-square)](https://packagist.org/packages/portphp/steps)
+
+**Requirements:** PHP ^8.2 (tested on 8.2–8.5).
+
 
 Step-based workflow for PortPHP.
 
@@ -22,7 +24,7 @@ of the Composer documentation.
 
 ## Documentation
 
-Documentation is available at https://portphp.readthedocs.org.
+Documentation is available at https://portphp.readthedocs.io.
 
 ## Issues and feature requests
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "support": {
         "issues": "https://github.com/portphp/portphp/issues",
         "source": "https://github.com/portphp/boilerplate",
-        "docs": "https://portphp.readthedocs.org"
+        "docs": "https://portphp.readthedocs.io"
     },
     "require": {
         "php": "^8.2",


### PR DESCRIPTION
## Summary
- Replace Travis/Scrutinizer badges with GitHub Actions
- Document PHP ^8.2 requirements
- Fix docs URL to readthedocs.io
- Remove `.scrutinizer.yml`

## Test plan
- [x] CI green
- [ ] Copilot review